### PR TITLE
chore: add maxHeight to styles options

### DIFF
--- a/src/components/Tooltip/Container.tsx
+++ b/src/components/Tooltip/Container.tsx
@@ -1,8 +1,8 @@
-import {ReactNode} from 'react';
+import { ReactNode } from 'react';
 
-import {getReactNodeText} from '~/modules/helpers';
+import { getReactNodeText } from '~/modules/helpers';
 
-import {TooltipRenderProps} from '~/types';
+import { TooltipRenderProps } from '~/types';
 
 import CloseButton from './CloseButton';
 

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -13,6 +13,7 @@ const defaultOptions = {
   textColor: '#333',
   width: 380,
   zIndex: 100,
+  maxHeight: window.innerHeight - 100,
 } satisfies StylesOptions;
 
 const buttonBase = {
@@ -38,7 +39,7 @@ export default function getStyles(props: Props, step: StepMerged) {
   const mergedStyles = deepmerge(styles ?? {}, step.styles ?? {});
   const options = deepmerge(defaultOptions, mergedStyles.options || {}) satisfies StylesOptions;
   const hideBeacon = step.placement === 'center' || step.disableBeacon;
-  let { width } = options;
+  let { maxHeight, width } = options;
 
   if (window.innerWidth > 480) {
     width = 380;
@@ -49,6 +50,13 @@ export default function getStyles(props: Props, step: StepMerged) {
       typeof options.width === 'number' && window.innerWidth < options.width
         ? window.innerWidth - 30
         : options.width;
+  }
+
+  if ('maxHeight' in options) {
+    maxHeight =
+      typeof options.maxHeight === 'number' && window.innerHeight < options.maxHeight
+        ? window.innerHeight - 100
+        : options.maxHeight;
   }
 
   const overlay = {
@@ -119,6 +127,8 @@ export default function getStyles(props: Props, step: StepMerged) {
     },
     tooltipContent: {
       padding: '20px 10px',
+      maxHeight,
+      overflowY: 'auto',
     },
     tooltipFooter: {
       alignItems: 'center',

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -102,6 +102,7 @@ export interface StylesOptions {
   arrowColor: string;
   backgroundColor: string;
   beaconSize: number;
+  maxHeight?: string | number;
   overlayColor: string;
   primaryColor: string;
   spotlightShadow: string;


### PR DESCRIPTION
Er wordt door de library van alles zelf geregeld qua styling. 
Ik heb voor nu een optie toegevoegd om de maxHeight van de tooltip_content tag in te kunnen stellen.